### PR TITLE
Implement `porter new` command

### DIFF
--- a/docs/commands/readme.md
+++ b/docs/commands/readme.md
@@ -1,7 +1,8 @@
 <!-- commands -->
-* [`porter hello PERSON`](#porter-hello-person)
-* [`porter hello world`](#porter-hello-world)
 * [`porter help [COMMANDS]`](#porter-help-commands)
+* [`porter new`](#porter-new)
+* [`porter pack carry`](#porter-pack-carry)
+* [`porter pack install`](#porter-pack-install)
 * [`porter plugins`](#porter-plugins)
 * [`porter plugins:install PLUGIN...`](#porter-pluginsinstall-plugin)
 * [`porter plugins:inspect PLUGIN...`](#porter-pluginsinspect-plugin)
@@ -11,44 +12,6 @@
 * [`porter plugins:uninstall PLUGIN...`](#porter-pluginsuninstall-plugin-1)
 * [`porter plugins:uninstall PLUGIN...`](#porter-pluginsuninstall-plugin-2)
 * [`porter plugins update`](#porter-plugins-update)
-
-## `porter hello PERSON`
-
-Say hello
-
-```
-USAGE
-  $ porter hello PERSON -f <value>
-
-ARGUMENTS
-  PERSON  Person to say hello to
-
-FLAGS
-  -f, --from=<value>  (required) Who is saying hello
-
-DESCRIPTION
-  Say hello
-
-EXAMPLES
-  $ oex hello friend --from oclif
-  hello friend from oclif! (./src/commands/hello/index.ts)
-```
-
-## `porter hello world`
-
-Say hello world
-
-```
-USAGE
-  $ porter hello world
-
-DESCRIPTION
-  Say hello world
-
-EXAMPLES
-  $ porter hello world
-  hello world! (./src/commands/hello/world.ts)
-```
 
 ## `porter help [COMMANDS]`
 
@@ -69,6 +32,61 @@ DESCRIPTION
 ```
 
 _See code: [@oclif/plugin-help](https://github.com/oclif/plugin-help/blob/v5.2.20/src/commands/help.ts)_
+
+## `porter new`
+
+Create a new Porter project
+
+```
+USAGE
+  $ porter new -n <value> [-b <value>] [-c <value>] [-s <value>] [-p <value>] [-d <value>]
+
+FLAGS
+  -b, --build=<value>            [default: vite] Build system for use in the project
+  -c, --css=<value>              [default: tailwind] CSS system
+  -d, --deploy-strategy=<value>  [default: blue-green] Deployment strategy
+  -n, --name=<value>             (required) Name of project
+  -p, --package-manager=<value>  [default: yarn] node package manager
+  -s, --scm=<value>              [default: github] Source management system
+
+DESCRIPTION
+  Create a new Porter project
+```
+
+## `porter pack carry`
+
+Copy file from pack
+
+```
+USAGE
+  $ porter pack carry [-c <value>] [-f <value>] [-p <value>]
+
+FLAGS
+  -c, --component=<value>  name of component installed from pack
+  -f, --file=<value>       picks the file in the component to carry from the pack; carry.json commands are not run
+  -p, --pack=<value>       name of pack to install
+
+DESCRIPTION
+  Copy file from pack
+```
+
+## `porter pack install`
+
+Install pack from GitHub repo
+
+```
+USAGE
+  $ porter pack install -r <value> [-g] [-p ssh|https]
+
+FLAGS
+  -g, --global             whether the pack should be installed globally
+  -p, --protocol=<option>  [default: SSH] protocol to use when cloning git repos
+                           <options: ssh|https>
+  -r, --repo=<value>       (required) repository containing pack
+
+DESCRIPTION
+  Install pack from GitHub repo
+```
 
 ## `porter plugins`
 
@@ -99,7 +117,7 @@ Installs a plugin into the CLI.
 
 ```
 USAGE
-  $ porter plugins:install PLUGIN...
+  $ porter plugins add plugins:install PLUGIN...
 
 ARGUMENTS
   PLUGIN  Plugin to install.
@@ -137,7 +155,7 @@ Displays installation properties of a plugin.
 
 ```
 USAGE
-  $ porter plugins:inspect PLUGIN...
+  $ porter plugins inspect PLUGIN...
 
 ARGUMENTS
   PLUGIN  [default: .] Plugin to inspect.
@@ -164,7 +182,7 @@ Installs a plugin into the CLI.
 
 ```
 USAGE
-  $ porter plugins:install PLUGIN...
+  $ porter plugins install PLUGIN...
 
 ARGUMENTS
   PLUGIN  Plugin to install.
@@ -204,15 +222,15 @@ Links a plugin into the CLI for development.
 
 ```
 USAGE
-  $ porter plugins:link PLUGIN
+  $ porter plugins link PLUGIN
 
 ARGUMENTS
   PATH  [default: .] path to plugin
 
 FLAGS
-  -h, --help      Show CLI help.
+  -h, --help          Show CLI help.
   -v, --verbose
-  --[no-]install  Install dependencies after linking the plugin.
+      --[no-]install  Install dependencies after linking the plugin.
 
 DESCRIPTION
   Links a plugin into the CLI for development.
@@ -234,7 +252,7 @@ Removes a plugin from the CLI.
 
 ```
 USAGE
-  $ porter plugins:uninstall PLUGIN...
+  $ porter plugins remove plugins:uninstall PLUGIN...
 
 ARGUMENTS
   PLUGIN  plugin to uninstall
@@ -257,7 +275,7 @@ Removes a plugin from the CLI.
 
 ```
 USAGE
-  $ porter plugins:uninstall PLUGIN...
+  $ porter plugins uninstall PLUGIN...
 
 ARGUMENTS
   PLUGIN  plugin to uninstall
@@ -282,7 +300,7 @@ Removes a plugin from the CLI.
 
 ```
 USAGE
-  $ porter plugins:uninstall PLUGIN...
+  $ porter plugins unlink plugins:uninstall PLUGIN...
 
 ARGUMENTS
   PLUGIN  plugin to uninstall

--- a/src/commands/new/index.ts
+++ b/src/commands/new/index.ts
@@ -1,39 +1,45 @@
-import { Command, Flags } from '@oclif/core'
-import { newProject } from '../../services/project/new.js'
+import {Command, Flags} from '@oclif/core'
+
+import {newProject} from '../../services/project/new.js'
 
 export default class New extends Command {
   static description = 'Create a new Porter project'
 
   static flags = {
-    name: Flags.string({
-      char: 'n',
-      description: 'Name of project',
-      required: true
-    }),
     build: Flags.string({
       char: 'b',
+      default: 'webpack',
       description: 'Build system for use in the project',
-      default: 'vite'
     }),
     css: Flags.string({
       char: 'c',
+      default: 'tailwind',
       description: 'CSS system',
-      default: 'tailwind'
+    }),
+    'deploy-strategy': Flags.string({
+      char: 'd',
+      default: 'blue-green',
+      description: 'Deployment strategy',
+    }),
+    name: Flags.string({
+      char: 'n',
+      description: 'Name of project',
+      required: true,
+    }),
+    'package-manager': Flags.string({
+      char: 'p',
+      default: 'yarn',
+      description: 'node package manager',
     }),
     scm: Flags.string({
       char: 's',
+      default: 'github',
       description: 'Source management system',
-      default: 'github'
     }),
-    "package-manager": Flags.string({
-      char: 'p',
-      description: "node package manager",
-      default: 'yarn'
-    })
   }
 
   async run(): Promise<void> {
-    const { flags } = await this.parse(New)
+    const {flags} = await this.parse(New)
     await newProject(flags.name)
   }
 }

--- a/src/commands/new/index.ts
+++ b/src/commands/new/index.ts
@@ -1,0 +1,39 @@
+import { Command, Flags } from '@oclif/core'
+import { newProject } from '../../services/project/new.js'
+
+export default class New extends Command {
+  static description = 'Create a new Porter project'
+
+  static flags = {
+    name: Flags.string({
+      char: 'n',
+      description: 'Name of project',
+      required: true
+    }),
+    build: Flags.string({
+      char: 'b',
+      description: 'Build system for use in the project',
+      default: 'vite'
+    }),
+    css: Flags.string({
+      char: 'c',
+      description: 'CSS system',
+      default: 'tailwind'
+    }),
+    scm: Flags.string({
+      char: 's',
+      description: 'Source management system',
+      default: 'github'
+    }),
+    "package-manager": Flags.string({
+      char: 'p',
+      description: "node package manager",
+      default: 'yarn'
+    })
+  }
+
+  async run(): Promise<void> {
+    const { flags } = await this.parse(New)
+    await newProject(flags.name)
+  }
+}

--- a/src/services/pack/install.ts
+++ b/src/services/pack/install.ts
@@ -2,7 +2,8 @@ import {fileExists, mkdir, removeFile} from '@shopify/cli-kit/node/fs'
 import {downloadGitRepository} from '@shopify/cli-kit/node/git'
 import {cwd} from '@shopify/cli-kit/node/path'
 
-import {GIT_FOLDER, LOCAL_PORTER_DIRECTORY, PROTOCOL_HTTPS} from '../../utilities/constants.js'
+import {GIT_FOLDER, LOCAL_PORTER_DIRECTORY} from '../../utilities/constants.js'
+import {githubUrl} from '../../utilities/github.js'
 import {getLocalDepotPath} from '../../utilities/pack.js'
 
 export async function install(repo: string, global: boolean, protocol: string): Promise<void> {
@@ -32,12 +33,4 @@ async function createLocalPackFolderIfMissing(): Promise<void> {
   if (!packFolderExists) {
     await mkdir(`${cwd()}/${LOCAL_PORTER_DIRECTORY}`)
   }
-}
-
-function githubUrl(protocol: string, repo: string): string {
-  if (protocol === PROTOCOL_HTTPS) {
-    return `https://github.com/${repo}`
-  }
-
-  return `git@github.com:${repo}`
 }

--- a/src/services/project/new.ts
+++ b/src/services/project/new.ts
@@ -1,0 +1,18 @@
+import {removeFile} from '@shopify/cli-kit/node/fs'
+import {downloadGitRepository} from '@shopify/cli-kit/node/git'
+import {cwd, joinPath} from '@shopify/cli-kit/node/path'
+
+import {GIT_FOLDER, PROTOCOL_SSH} from '../../utilities/constants.js'
+import {githubUrl} from '../../utilities/github.js'
+
+export async function newProject(name: string) {
+  const projectPath = joinPath(cwd(), name)
+
+  await downloadGitRepository({
+    destination: projectPath,
+    repoUrl: githubUrl(PROTOCOL_SSH, 'TheBeyondGroup/porter-template'),
+    shallow: true,
+  })
+
+  await removeFile(joinPath(projectPath, GIT_FOLDER))
+}

--- a/src/utilities/github.ts
+++ b/src/utilities/github.ts
@@ -1,0 +1,9 @@
+import {PROTOCOL_HTTPS} from './constants.js'
+
+export function githubUrl(protocol: string, repo: string): string {
+  if (protocol === PROTOCOL_HTTPS) {
+    return `https://github.com/${repo}`
+  }
+
+  return `git@github.com:${repo}`
+}


### PR DESCRIPTION
In this PR, I introduce the `porter new` command.


`porter new` creates a new Shopify storefront project.

It builds the project folder structure, sets up the build system, sets up Shopkeeper and generally prepares the project for development.