### PR TITLE
chore: define pack install command

### DIFF
--- a/docs/spec-cli.md
+++ b/docs/spec-cli.md
@@ -25,6 +25,17 @@ Flags:
 
 - `-f`, `--from` is required
 
+## `porter pack install --repo <pack repo name>`
+
+Given, the `--repo` flag, this command downloads the passed 'org/repo-name'
+from GitHub to `./.porter`.
+
+Flags:
+
+- `-r`, `--repo` is required
+- `-g`, `--global` sets the download directory to `.config/porter` and creates
+a symbolic link to the local `.porter` directory
+
 ## `porter pack carry --pack <pack name>`
 
 Given the `--pack` flag, this command installs all the pack components in the pack.

--- a/docs/spec-pack.md
+++ b/docs/spec-pack.md
@@ -55,3 +55,8 @@ Proposed structure
 ```
 {command: "log", options: {text: "Hello World"}}
 ```
+
+## Worfklow
+
+To build a pack, use the `porter pack extract` to copy components from the theme
+componenet directories to the local pack store (`./.porter`).


### PR DESCRIPTION
The `pack install` command is what is used to get a pack into your storefront tooling. This command completes the command necessary to build a pack.