### PR TITLE
Implement `porter pack carry` command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 dist
+.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 node_modules
 dist
 .DS_Store
+theme
+.porter

--- a/docs/spec-cli.md
+++ b/docs/spec-cli.md
@@ -14,7 +14,7 @@ Flags:
 - `-s`, `--source-code-host` sets the source code host, defaults to [GITHUB]
 - `-p`, `--package` sets the node package manager, defaults to [YARN]
 
-## `porter migrate --from <path>`
+## `porter migrate --from <path to theme>`
 
 Given the `--from` flag, this command moves the contents of the standard Shopify
 theme directories and places them in the Porter structure.

--- a/docs/spec-pack.md
+++ b/docs/spec-pack.md
@@ -53,7 +53,10 @@ A global `carry.json` defines any additional steps necessary to install all pack
 Proposed structure
 
 ```
-{command: "log", options: {text: "Hello World"}}
+[
+    {command: "log", options: {text: "Hello World"}},
+    {command: "install_package", options: {name: "@shopify/cli-kit"}},
+]
 ```
 
 ## Worfklow

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "topicSeparator": " "
   },
   "dependencies": {
-    "@oclif/core": "^3",
+    "@oclif/core": "2.11.7",
     "@oclif/plugin-help": "^5",
     "@oclif/plugin-plugins": "^3.9.1",
     "@shopify/cli-kit": "^3.53.0"
@@ -44,8 +44,10 @@
     "@oclif/prettier-config": "^0.2.1",
     "@oclif/test": "^3",
     "@types/chai": "^4",
+    "@types/diff": "^5.0.9",
     "@types/mocha": "^10",
     "@types/node": "^18",
+    "@types/react": "^18.2.47",
     "chai": "^4",
     "eslint": "^8",
     "eslint-config-oclif": "^5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,8 +6,8 @@ settings:
 
 dependencies:
   '@oclif/core':
-    specifier: ^3
-    version: 3.2.1
+    specifier: 2.11.7
+    version: 2.11.7(@types/node@18.18.5)(typescript@5.2.2)
   '@oclif/plugin-help':
     specifier: ^5
     version: 5.2.20(@types/node@18.18.5)(typescript@5.2.2)
@@ -16,7 +16,7 @@ dependencies:
     version: 3.9.1(@types/node@18.18.5)(typescript@5.2.2)
   '@shopify/cli-kit':
     specifier: ^3.53.0
-    version: 3.53.0(@types/node@18.18.5)(typescript@5.2.2)
+    version: 3.53.0(@types/node@18.18.5)(@types/react@18.2.47)(typescript@5.2.2)
 
 devDependencies:
   '@commitlint/cli':
@@ -34,12 +34,18 @@ devDependencies:
   '@types/chai':
     specifier: ^4
     version: 4.3.8
+  '@types/diff':
+    specifier: ^5.0.9
+    version: 5.0.9
   '@types/mocha':
     specifier: ^10
     version: 10.0.2
   '@types/node':
     specifier: ^18
     version: 18.18.5
+  '@types/react':
+    specifier: ^18.2.47
+    version: 18.2.47
   chai:
     specifier: ^4
     version: 4.3.10
@@ -930,7 +936,6 @@ packages:
       - '@swc/wasm'
       - '@types/node'
       - typescript
-    dev: false
 
   /@oclif/core@2.15.0(@types/node@18.18.5)(typescript@5.2.2):
     resolution: {integrity: sha512-fNEMG5DzJHhYmI3MgpByTvltBOMyFcnRIUMxbiz2ai8rhaYgaTHMG3Q38HcosfIvtw9nCjxpcQtC8MN8QtVCcA==}
@@ -999,6 +1004,7 @@ packages:
       widest-line: 3.1.0
       wordwrap: 1.0.0
       wrap-ansi: 7.0.0
+    dev: true
 
   /@oclif/plugin-help@5.2.20(@types/node@18.18.5)(typescript@5.2.2):
     resolution: {integrity: sha512-u+GXX/KAGL9S10LxAwNUaWdzbEBARJ92ogmM7g3gDVud2HioCmvWQCDohNRVZ9GYV9oKwZ/M8xwd6a1d95rEKQ==}
@@ -1473,7 +1479,7 @@ packages:
     dev: true
     optional: true
 
-  /@shopify/cli-kit@3.53.0(@types/node@18.18.5)(typescript@5.2.2):
+  /@shopify/cli-kit@3.53.0(@types/node@18.18.5)(@types/react@18.2.47)(typescript@5.2.2):
     resolution: {integrity: sha512-Rw5koF98VoiD5bbZ2Sd0UsmZY1aP6U6I+IUJKcu1V59BQgvHoVkIAnok7wkzUWbwjDQNH5kf/edwC8HgLpEXjA==}
     engines: {node: '>=18.12.0'}
     os: [darwin, linux, win32]
@@ -1516,7 +1522,7 @@ packages:
       gradient-string: 2.0.2
       graphql: 16.8.1
       graphql-request: 5.2.0(graphql@16.8.1)
-      ink: 4.4.1(react@18.2.0)
+      ink: 4.4.1(@types/react@18.2.47)(react@18.2.0)
       is-interactive: 2.0.0
       js-yaml: 4.1.0
       kill-port-process: 3.1.0
@@ -1705,6 +1711,10 @@ packages:
     dependencies:
       '@types/node': 18.18.5
 
+  /@types/diff@5.0.9:
+    resolution: {integrity: sha512-RWVEhh/zGXpAVF/ZChwNnv7r4rvqzJ7lYNSmZSVTxjV0PBLf6Qu7RNg+SUtkpzxmiNkjCx0Xn2tPp7FIkshJwQ==}
+    dev: true
+
   /@types/estree@1.0.5:
     resolution: {integrity: sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==}
     dev: true
@@ -1761,6 +1771,16 @@ packages:
     resolution: {integrity: sha512-lqa4UEhhv/2sjjIQgjX8B+RBjj47eo0mzGasklVJ78UKGQY1r0VpB9XHDaZZO9qzEFDdy4MrXLuEaSmPrPSe/A==}
     dev: true
 
+  /@types/prop-types@15.7.11:
+    resolution: {integrity: sha512-ga8y9v9uyeiLdpKddhxYQkxNDrfvuPrlFb0N1qnZZByvcElJaXthF1UhvCh9TLWJBEHeNtdnbysW7Y6Uq8CVng==}
+
+  /@types/react@18.2.47:
+    resolution: {integrity: sha512-xquNkkOirwyCgoClNk85BjP+aqnIS+ckAJ8i37gAbDs14jfW/J23f2GItAf33oiUPQnqNMALiFeoM9Y5mbjpVQ==}
+    dependencies:
+      '@types/prop-types': 15.7.11
+      '@types/scheduler': 0.16.8
+      csstype: 3.1.3
+
   /@types/readdir-glob@1.1.5:
     resolution: {integrity: sha512-raiuEPUYqXu+nvtY2Pe8s8FEmZ3x5yAH4VkLdihcPdalvsHltomrRC9BzuStrJ9yk06470hS0Crw0f1pXqD+Hg==}
     dependencies:
@@ -1772,6 +1792,9 @@ packages:
     dependencies:
       '@types/node': 18.18.5
     dev: true
+
+  /@types/scheduler@0.16.8:
+    resolution: {integrity: sha512-WZLiwShhwLRmeV6zH+GkbOFT6Z6VklCItrDioxUnv+u4Ll+8vKeFySoFyK/0ctcRpOmwAicELfmys1sDc/Rw+A==}
 
   /@types/semver@7.5.3:
     resolution: {integrity: sha512-OxepLK9EuNEIPxWNME+C6WwbRAOOI2o2BaQEGzz5Lu2e4Z5eDnEo+/aVEDMIXywoJitJ7xWd641wrGLZdtwRyw==}
@@ -2306,7 +2329,6 @@ packages:
   /at-least-node@1.0.0:
     resolution: {integrity: sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==}
     engines: {node: '>= 4.0.0'}
-    dev: false
 
   /atomically@2.0.2:
     resolution: {integrity: sha512-Xfmb4q5QV7uqTlVdMSTtO5eF4DCHfNOdaPyKlbFShkzeNP+3lj3yjjcbdjSmEY4+pDBKJ9g26aP+ImTe88UHoQ==}
@@ -3049,6 +3071,9 @@ packages:
     dependencies:
       type-fest: 1.4.0
     dev: false
+
+  /csstype@3.1.3:
+    resolution: {integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==}
 
   /dargs@7.0.0:
     resolution: {integrity: sha512-2iy1EkLdlBzQGvbweYRFxmFath8+K7+AKB0TlhHWkNuH+TmovaMH/Wp7V7R4u7f4SnX3OgLsU9t1NI9ioDnUpg==}
@@ -4199,7 +4224,6 @@ packages:
       graceful-fs: 4.2.11
       jsonfile: 6.1.0
       universalify: 2.0.0
-    dev: false
 
   /fs-minipass@2.1.0:
     resolution: {integrity: sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==}
@@ -4794,7 +4818,7 @@ packages:
   /ini@1.3.8:
     resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
 
-  /ink@4.4.1(react@18.2.0):
+  /ink@4.4.1(@types/react@18.2.47)(react@18.2.0):
     resolution: {integrity: sha512-rXckvqPBB0Krifk5rn/5LvQGmyXwCUpBfmTwbkQNBY9JY8RSl3b8OftBNEYxg4+SWUhEKcPifgope28uL9inlA==}
     engines: {node: '>=14.16'}
     peerDependencies:
@@ -4808,6 +4832,7 @@ packages:
         optional: true
     dependencies:
       '@alcalzone/ansi-tokenize': 0.1.3
+      '@types/react': 18.2.47
       ansi-escapes: 6.2.0
       auto-bind: 5.0.1
       chalk: 5.3.0
@@ -6401,7 +6426,7 @@ packages:
     engines: {node: '>=12.0.0'}
     hasBin: true
     dependencies:
-      '@oclif/core': 2.15.0(@types/node@18.18.5)(typescript@5.2.2)
+      '@oclif/core': 2.11.7(@types/node@18.18.5)(typescript@5.2.2)
       '@oclif/plugin-help': 5.2.20(@types/node@18.18.5)(typescript@5.2.2)
       '@oclif/plugin-not-found': 2.4.3(@types/node@18.18.5)(typescript@5.2.2)
       '@oclif/plugin-warn-if-update-available': 2.1.1(@types/node@18.18.5)(typescript@5.2.2)

--- a/src/commands/pack/carry.ts
+++ b/src/commands/pack/carry.ts
@@ -1,0 +1,44 @@
+import {Command, Errors, Flags} from '@oclif/core'
+import {errorHandler} from '@shopify/cli-kit/node/error-handler'
+
+import {carry} from '../../services/pack/carry.js'
+
+export default class Carry extends Command {
+  static description = 'Copy file from pack'
+
+  static flags = {
+    component: Flags.string({
+      char: 'c',
+      default: '',
+      description: 'name of component installed from pack',
+    }),
+    file: Flags.string({
+      char: 'f',
+      default: '',
+      description: 'picks the file in the component to carry from the pack; carry.json commands are not run',
+    }),
+    pack: Flags.string({
+      char: 'p',
+      default: '',
+      description: 'name of pack to install',
+      require: true,
+    }),
+  }
+
+  async catch(error: Error & {exitCode?: number | undefined}): Promise<void> {
+    await errorHandler(error, this.config)
+    return Errors.handle(error)
+  }
+
+  async run(): Promise<void> {
+    const {flags} = await this.parse(Carry)
+    await carry(flags.pack, flags.component, flags.file)
+    // What kind of outputs do we need?
+    //  oclif will manage making sure we get the right arguments
+    //  error if the pack doesn't exist in a depot
+    //  error if the component doesn't exist in the pack
+    //  progress as files are moved; should be able to do the file operations in parallel
+    //  progress as carry file commands are executed
+    //  summary when steps are complete
+  }
+}

--- a/src/commands/pack/install.ts
+++ b/src/commands/pack/install.ts
@@ -1,6 +1,6 @@
 import {Command, Flags} from '@oclif/core'
 
-import {installPack} from '../../services/pack/install.js'
+import {install} from '../../services/pack/install.js'
 
 export default class Install extends Command {
   static description = 'Install pack from GitHub repo'
@@ -21,6 +21,6 @@ export default class Install extends Command {
 
   async run(): Promise<void> {
     const {flags} = await this.parse(Install)
-    await installPack(flags.repo, flags.global)
+    await install(flags.repo, flags.global)
   }
 }

--- a/src/commands/pack/install.ts
+++ b/src/commands/pack/install.ts
@@ -1,6 +1,7 @@
 import {Command, Flags} from '@oclif/core'
 
 import {install} from '../../services/pack/install.js'
+import {GIT_PROTOCOLS} from '../../utilities/constants.js'
 
 export default class Install extends Command {
   static description = 'Install pack from GitHub repo'
@@ -12,6 +13,12 @@ export default class Install extends Command {
       description: 'whether the pack should be installed globally',
       required: false,
     }),
+    protocol: Flags.string({
+      char: 'p',
+      default: 'SSH',
+      description: 'protocol to use when cloning git repos',
+      options: GIT_PROTOCOLS,
+    }),
     repo: Flags.string({
       char: 'r',
       description: 'repository containing pack',
@@ -21,6 +28,6 @@ export default class Install extends Command {
 
   async run(): Promise<void> {
     const {flags} = await this.parse(Install)
-    await install(flags.repo, flags.global)
+    await install(flags.repo, flags.global, flags.protocol)
   }
 }

--- a/src/services/pack/carry.ts
+++ b/src/services/pack/carry.ts
@@ -1,0 +1,13 @@
+import {carryPack, carryPackComponent, carryPackComponentFile} from '../../utilities/pack.js'
+
+export async function carry(pack: string, component: string, file: string) {
+  if (component.length > 0 && file.length > 0) {
+    return carryPackComponentFile(pack, component, file)
+  }
+
+  if (component.length > 0) {
+    return carryPackComponent(pack, component)
+  }
+
+  return carryPack(pack)
+}

--- a/src/services/pack/install.ts
+++ b/src/services/pack/install.ts
@@ -2,10 +2,9 @@ import {fileExists, findPathUp, mkdir, removeFile} from '@shopify/cli-kit/node/f
 import {downloadGitRepository} from '@shopify/cli-kit/node/git'
 import {cwd} from '@shopify/cli-kit/node/path'
 
-export async function installPack(repo: string, global: boolean) {
+export async function install(repo: string, global: boolean) {
   await createLocalPackFolderIfMissing()
   const localPorterDirectory = await getLocalPorterDirectory()
-  console.log(localPorterDirectory)
   const pack = getPackNameFromRepo(repo)
   const localPackDirectory = `${localPorterDirectory}/${pack}`
 

--- a/src/services/pack/install.ts
+++ b/src/services/pack/install.ts
@@ -1,21 +1,24 @@
-import {fileExists, findPathUp, mkdir, removeFile} from '@shopify/cli-kit/node/fs'
+import {fileExists, mkdir, removeFile} from '@shopify/cli-kit/node/fs'
 import {downloadGitRepository} from '@shopify/cli-kit/node/git'
 import {cwd} from '@shopify/cli-kit/node/path'
 
-export async function install(repo: string, global: boolean) {
+import {GIT_FOLDER, LOCAL_PORTER_DIRECTORY, PROTOCOL_HTTPS} from '../../utilities/constants.js'
+import {getLocalDepotPath} from '../../utilities/pack.js'
+
+export async function install(repo: string, global: boolean, protocol: string): Promise<void> {
   await createLocalPackFolderIfMissing()
-  const localPorterDirectory = await getLocalPorterDirectory()
+  const localPorterDirectory = await getLocalDepotPath()
   const pack = getPackNameFromRepo(repo)
   const localPackDirectory = `${localPorterDirectory}/${pack}`
 
   await downloadGitRepository({
     destination: localPackDirectory,
-    repoUrl: githubUrl(repo),
+    repoUrl: githubUrl(protocol, repo),
     shallow: true,
   })
 
   if (!global) {
-    await removeFile(`${localPackDirectory}/.git`)
+    await removeFile(`${localPackDirectory}/${GIT_FOLDER}`)
   }
 }
 
@@ -23,18 +26,18 @@ function getPackNameFromRepo(repo: string): string {
   return repo.split('/')[1]
 }
 
-async function createLocalPackFolderIfMissing() {
-  const packFolderExists = await fileExists(`${cwd()}/.porter`)
+async function createLocalPackFolderIfMissing(): Promise<void> {
+  const packFolderExists = await fileExists(`${cwd()}/${LOCAL_PORTER_DIRECTORY}`)
 
   if (!packFolderExists) {
-    await mkdir(`${cwd()}/.porter`)
+    await mkdir(`${cwd()}/${LOCAL_PORTER_DIRECTORY}`)
   }
 }
 
-function githubUrl(repo: string) {
-  return `https://github.com/${repo}`
-}
+function githubUrl(protocol: string, repo: string): string {
+  if (protocol === PROTOCOL_HTTPS) {
+    return `https://github.com/${repo}`
+  }
 
-async function getLocalPorterDirectory() {
-  return findPathUp('.porter', {type: 'directory'})
+  return `git@github.com:${repo}`
 }

--- a/src/utilities/carry-file.ts
+++ b/src/utilities/carry-file.ts
@@ -1,0 +1,31 @@
+import {readFile} from '@shopify/cli-kit/node/fs'
+import {consoleLog, outputInfo} from '@shopify/cli-kit/node/output'
+
+export type LogOperation = {
+  message: string
+}
+
+export type CarryOperation = {
+  command: string
+  options: LogOperation
+}
+
+const OPERATIONS: {[key: string]: (opt: LogOperation) => void} = {
+  log: logOperation,
+}
+
+function logOperation(options: LogOperation) {
+  outputInfo(options.message)
+}
+
+export async function loadCarryFile(path: string): Promise<any> {
+  const carryFileContents = await readFile(path)
+  const carryFile = JSON.parse(carryFileContents)
+  return carryFile
+}
+
+export function executeCarryFile(operations: CarryOperation[]) {
+  for (const op of operations) {
+    OPERATIONS[op.command](op.options)
+  }
+}

--- a/src/utilities/constants.ts
+++ b/src/utilities/constants.ts
@@ -1,2 +1,6 @@
 export const LOCAL_PORTER_DIRECTORY = '.porter'
 export const CARRY_FILE = 'carry.json'
+export const PROTOCOL_SSH = 'ssh'
+export const PROTOCOL_HTTPS = 'https'
+export const GIT_PROTOCOLS = [PROTOCOL_SSH, PROTOCOL_HTTPS]
+export const GIT_FOLDER = '.git'

--- a/src/utilities/constants.ts
+++ b/src/utilities/constants.ts
@@ -1,0 +1,2 @@
+export const LOCAL_PORTER_DIRECTORY = '.porter'
+export const CARRY_FILE = 'carry.json'

--- a/src/utilities/pack.ts
+++ b/src/utilities/pack.ts
@@ -1,0 +1,237 @@
+import {AbortError} from '@shopify/cli-kit/node/error'
+import {copyFile, fileExists, findPathUp, glob} from '@shopify/cli-kit/node/fs'
+import {outputContent, outputToken} from '@shopify/cli-kit/node/output'
+import {basename, cwd, joinPath, resolvePath} from '@shopify/cli-kit/node/path'
+
+import {executeCarryFile, loadCarryFile} from './carry-file.js'
+import {CARRY_FILE, LOCAL_PORTER_DIRECTORY} from './constants.js'
+
+export enum Depot {
+  Local,
+  Global,
+  NotFound,
+}
+
+export type FileMove = {
+  dest: string
+  file: string
+  source: string
+}
+
+export async function carryPackComponentFile(pack: string, component: string, file: string): Promise<void> {
+  await ensurePackExists(pack)
+
+  const depot = await findPack(pack)
+
+  await ensurePackHasComponent(depot, pack, component)
+  await ensureThemeComponentsFolderPresent()
+
+  const fileMove: FileMove = {
+    dest: await getThemeComponentFilePath(component, file),
+    file,
+    source: await getLocalPackComponentFilePath(pack, component, file),
+  }
+
+  await copyFiles([fileMove])
+}
+
+export async function carryPackComponent(pack: string, component: string): Promise<void> {
+  await ensurePackExists(pack)
+
+  const depot = await findPack(pack)
+  await ensurePackHasComponent(depot, pack, component)
+  await ensureThemeComponentsFolderPresent()
+
+  await copyPackComponent(depot, pack, component)
+  await executeComponentCarry(pack, component)
+}
+
+export async function carryPack(pack: string): Promise<void> {
+  await ensurePackExists(pack)
+  await ensureThemeComponentsFolderPresent()
+
+  const depot = await findPack(pack)
+  const components = await getPackComponentNames(depot, pack)
+
+  await Promise.all(
+    components.map(async (component: string) =>
+      Promise.all([copyPackComponent(depot, pack, component), executeComponentCarry(pack, component)]),
+    ),
+  )
+}
+
+export async function getPackComponents(depot: Depot, pack: string) {
+  const depotPath = await getDepotPath(depot)
+  const packPath = joinPath(depotPath, pack)
+  return glob(`${packPath}/*`, {deep: 1, onlyDirectories: true})
+}
+
+export async function getPackComponentNames(depot: Depot, pack: string) {
+  const componentPaths = await getPackComponents(depot, pack)
+  return componentPaths.map((path) => basename(path))
+}
+
+export async function getPackComponentFiles(depot: Depot, pack: string, component: string): Promise<string[]> {
+  const depotPath = await getDepotPath(depot)
+  const packPath = joinPath(depotPath, pack, component)
+  const componentFiles = await glob(`${packPath}/*`, {
+    ignore: ['*.md', '**/carry.json'],
+  })
+  return componentFiles
+}
+
+export async function getLocalDepotPath(): Promise<string> {
+  const localPorterPath = await findPathUp(LOCAL_PORTER_DIRECTORY, {type: 'directory'})
+
+  if (!localPorterPath) {
+    throw new AbortError(
+      outputContent`Cannot find ${LOCAL_PORTER_DIRECTORY} directory when searching up from ${outputToken.path(cwd())}.`,
+    )
+  }
+
+  return localPorterPath
+}
+
+export async function getGlobalDepotPath(): Promise<string> {
+  return ''
+}
+
+export async function getLocalPackPaths(): Promise<string[]> {
+  const localDepotPath = await getLocalDepotPath()
+  return glob(`${localDepotPath}/*`, {deep: 1, onlyDirectories: true})
+}
+
+export async function getLocalPackNames(): Promise<string[]> {
+  const packs = await getLocalPackPaths()
+  return packs.map((path) => basename(path))
+}
+
+export async function getLocalPackComponentPath(pack: string, component: string) {
+  const localDepotPath = await getLocalDepotPath()
+  return joinPath(localDepotPath, pack, component)
+}
+
+export async function getLocalPackComponentFilePath(pack: string, component: string, file: string) {
+  const localDepotPath = await getLocalDepotPath()
+  return joinPath(localDepotPath, pack, component, file)
+}
+
+export async function getDepotPath(depot: Depot) {
+  switch (depot) {
+    case Depot.Local: {
+      return getLocalDepotPath()
+    }
+
+    case Depot.Global: {
+      return getGlobalDepotPath()
+    }
+
+    default: {
+      return ''
+    }
+  }
+}
+
+export async function findPack(pack: string): Promise<Depot> {
+  // look in project .porter directory, called a depot
+  const localPacks = await getLocalPackNames()
+  const inLocalDepot = localPacks.includes(pack)
+
+  if (inLocalDepot) {
+    return Depot.Local
+  }
+
+  return Depot.NotFound
+}
+
+export async function depotHasPack(pack: string): Promise<boolean> {
+  const searchResult = await findPack(pack)
+  return searchResult !== Depot.NotFound
+}
+
+export async function hasPackComponent(depot: Depot, pack: string, component: string) {
+  const depotPath = await getDepotPath(depot)
+  const componentPath = joinPath(depotPath, pack, component)
+  return fileExists(componentPath)
+}
+
+export async function hasPackComponentFile(depot: Depot, pack: string, component: string, file: string) {
+  const depotPath = await getDepotPath(depot)
+  const filePath = joinPath(depotPath, pack, component, file)
+  return fileExists(filePath)
+}
+
+export async function copyFiles(moves: FileMove[]) {
+  await Promise.all(moves.map(async (move) => copyFile(move.source, move.dest)))
+}
+
+export async function getProjectPath() {
+  const depotPath = await getLocalDepotPath()
+  const projectRootPath = resolvePath(depotPath, '..')
+  return projectRootPath
+}
+
+export async function getThemePath(): Promise<string> {
+  const projectPath = await getProjectPath()
+  return joinPath(projectPath, 'theme')
+}
+
+export async function getThemeComponentsPath(): Promise<string> {
+  const themePath = await getThemePath()
+  return joinPath(themePath, 'components')
+}
+
+export async function getThemeComponentPath(component: string): Promise<string> {
+  const themeComponentPackPath = await getThemeComponentsPath()
+  return joinPath(themeComponentPackPath, component)
+}
+
+export async function getThemeComponentFilePath(component: string, file: string): Promise<string> {
+  const themeComponentPackPath = await getThemeComponentPath(component)
+  return joinPath(themeComponentPackPath, file)
+}
+
+export async function ensurePackExists(pack: string) {
+  const hasPack = await depotHasPack(pack)
+  if (!hasPack) {
+    const localDepotPath = await getLocalDepotPath()
+    throw new AbortError(outputContent`Cannot find ${pack} in ${localDepotPath}.`)
+  }
+}
+
+export async function ensurePackHasComponent(depot: Depot, pack: string, component: string) {
+  const hasComponent = await hasPackComponent(depot, pack, component)
+  if (!hasComponent) {
+    const localPackComponentPath = await getLocalPackComponentPath(pack, component)
+    throw new AbortError(outputContent`Cannot find ${component} in ${localPackComponentPath}.`)
+  }
+}
+
+export async function ensureThemeComponentsFolderPresent(): Promise<void> {
+  const themeComponentsPath = await getThemeComponentsPath()
+  const exists = fileExists(themeComponentsPath)
+
+  if (!exists) {
+    throw new AbortError(outputContent`Cannot find ${themeComponentsPath} directory.`)
+  }
+}
+
+export async function copyPackComponent(depot: Depot, pack: string, component: string) {
+  const componentFiles = await getPackComponentFiles(depot, pack, component)
+
+  // copy files in component folder to theme component folder
+  const moves = await Promise.all(
+    componentFiles.map(async (filePath) => ({
+      dest: await getThemeComponentFilePath(component, basename(filePath)),
+      file: basename(filePath),
+      source: filePath,
+    })),
+  )
+  await copyFiles(moves)
+}
+
+export async function executeComponentCarry(pack: string, component: string) {
+  const carryFilePath = await getLocalPackComponentFilePath(pack, component, CARRY_FILE)
+  const carryOperations = await loadCarryFile(carryFilePath)
+  executeCarryFile(carryOperations)
+}


### PR DESCRIPTION
In this PR, I implement a first pass on on the pack carry command.


## `porter pack carry --pack <pack name>`

Given the `--pack` flag, this command installs all the pack components in the pack.

Flags:

- `-p`, `--pack` is required

## `porter pack carry --pack <path to pack> --component <component name>`

Given the `--pack` and `--component` flags, this command installs a component from a pack.

Flags:

- `-p`, `--pack` is required
- `-c`, `--component` is optional, picks the component to carry from the pack

## `porter pack carry --pack <path to pack> --component <component> --file <file>`

Given the `--pack`, `--component`, and `--file` flags, this command copies just the passed name
into it's corresponding component

Flags:

- `-p`, `--pack` is required
- `-c`, `--component` is optional, picks the component to carry from the pack
- `-f`, `--file` is optional, picks the file in the component to carry from the pack; carry.json commands are not run

---

Fixes TOOLS-85